### PR TITLE
Fix DI error in case sensitive environments

### DIFF
--- a/src/MatrixMate.php
+++ b/src/MatrixMate.php
@@ -13,7 +13,7 @@ namespace vaersaagod\matrixmate;
 use craft\services\Fields;
 use craft\services\Sections;
 use craft\web\Application;
-use vaersaagod\matrixmate\assetbundles\MatrixMate\MatrixMateAsset;
+use vaersaagod\matrixmate\assetbundles\matrixmate\MatrixMateAsset;
 use vaersaagod\matrixmate\services\MatrixMateService;
 use vaersaagod\matrixmate\models\Settings;
 

--- a/src/assetbundles/matrixmate/MatrixMateAsset.php
+++ b/src/assetbundles/matrixmate/MatrixMateAsset.php
@@ -8,7 +8,7 @@
  * @copyright Copyright (c) 2019 Værsågod
  */
 
-namespace vaersaagod\matrixmate\assetbundles\MatrixMate;
+namespace vaersaagod\matrixmate\assetbundles\matrixmate;
 
 use Craft;
 use craft\helpers\Json;


### PR DESCRIPTION
The MatrixMateAsset is in the folder `matrixmate` however, it's class namespace uses `MatrixMate`. This causes issues in strict case sensitive environments where Composer is incapable of locating the correct files.

This PR just fixes the namespace to be inline with the folder name.