### PR TITLE
Add option to render default tab first instead of last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.2.8 - 2021-09-20
+
+### Added
+- Added the `defaultTabFirst` config setting for tabs, to allow displaying the default tab first
+
 ## 1.2.7 - 2020-08-15
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "vaersaagod/matrixmate",
     "description": "Welding Matrix into shape, mate!",
     "type": "craft-plugin",
-    "version": "1.2.7",
+    "version": "1.2.8",
     "keywords": [
         "craft",
         "cms",

--- a/src/assetbundles/matrixmate/dist/js/MatrixMate.js
+++ b/src/assetbundles/matrixmate/dist/js/MatrixMate.js
@@ -416,11 +416,17 @@
 
                 var renderDefaultTab = !!(typeConfig['defaultTabName'] || null) || (!numTabs && hiddenFields.length);
 
-                tabs.push({
+                var defaultTabOptions = {
                     label: typeConfig['defaultTabName'] || Craft.t('Fields'),
                     isDefaultTab: true,
                     render: renderDefaultTab
-                });
+                };
+
+                if (typeConfig['defaultTabFirst']) {
+                    tabs.unshift(defaultTabOptions);
+                } else {
+                    tabs.push(defaultTabOptions);
+                }
 
                 var namespace = $field.prop('id') + '-' + $block.data('id');
 
@@ -444,6 +450,11 @@
 
                 var blockColor = $block.css('backgroundColor');
 
+                // Get list of config tab fields
+                var tabFields = tabs.reduce(function(fields, group) {
+                    return group['fields'] ? fields.concat(group['fields']) : fields;
+                } , []);
+
                 for (var i = 0; i < tabs.length; i++) {
 
                     var navClasses = '';
@@ -461,6 +472,9 @@
                             return;
                         }
                         if (!tabs[i].isDefaultTab && tabFieldHandles.indexOf(handle) === -1) {
+                            return;
+                        }
+                        if (tabs[i].isDefaultTab && tabFields.indexOf(handle) > -1) {
                             return;
                         }
                         usedFields.push(handle);

--- a/src/services/MatrixMateService.php
+++ b/src/services/MatrixMateService.php
@@ -92,7 +92,7 @@ class MatrixMateService extends Component
                 continue;
             }
 
-            if (!empty(\array_intersect(['groups', 'types', 'hiddenTypes', 'hideUngroupedTypes', 'defaultTabName'], \array_keys($settings)))) {
+            if (!empty(\array_intersect(['groups', 'types', 'hiddenTypes', 'hideUngroupedTypes', 'defaultTabName', 'defaultTabFirst'], \array_keys($settings)))) {
                 $settings = ['*' => $settings];
             }
 
@@ -228,6 +228,8 @@ class MatrixMateService extends Component
             } else if (\is_string($defaultTabName)) {
                 $defaultTabName = Craft::t('site', $defaultTabName);
             }
+            // Get default tab position
+            $defaultTabFirst = $typeConfig['defaultTabFirst'] ?? $array['defaultTabFirst'] ?? false;
             // Get max limit
             $maxLimit = $typeConfig['maxLimit'] ?? null;
             if ($maxLimit !== null) {
@@ -246,6 +248,7 @@ class MatrixMateService extends Component
             $typeConfig = [
                 'tabs' => $tabs,
                 'defaultTabName' => $defaultTabName,
+                'defaultTabFirst' => $defaultTabFirst,
                 'maxLimit' => $maxLimit,
                 'hiddenFields' => $hiddenFields,
             ];


### PR DESCRIPTION
Setting the option `'defaultTabFirst' => true` alongside `defaultTabName` allows rendering the default tab listing first (which also selects it as the active tab by default).