### PR TITLE
fix associative arrays for tabs config

### DIFF
--- a/src/services/MatrixMateService.php
+++ b/src/services/MatrixMateService.php
@@ -272,6 +272,6 @@ class MatrixMateService extends Component
                 'fields' => $tab['fields'] ?? $tab,
             ];
         }
-        return $tabs;
+        return array_values($tabs);
     }
 }


### PR DESCRIPTION
Using an associative array for the tabs config seems to be implemented in the function `MatrixMateService::getTabsConfigFromArray()`, but won't actually work.

I'd prefer to use an associative array, since it keeps the config file shorter.

```
'tabs' => [[
    'label' => 'Text',
    'fields' => ['heading', 'text'],
], [
    'label' => 'Settings',
    'fields' => ['columns'],
]]
```

```
'tabs' => [
  'Text'  => ['heading', 'text'],
  'Settings'  => ['columns'],
]
```

I would expect those two settings to produce the same result. Looking at the function handling this part, this seems to be the intended behaviour. But when converting these settings to JSON we get this:

```
"tabs": [{
    "label": "Text",
    "fields": ["heading", "text"]
}, {
    "label": "Settings",
    "fields": ["columns"]
}]
```

```
"tabs": {
    "Text": {
        "label": "Text",
        "fields": ["heading", "text"]
    },
    "Settings": {
        "label": "Settings",
        "fields": ["columns"]
    }
}
```

The second JSON code will currently fail, since it's not an array, but an object. This PR makes sure, that the `getTabsConfigFromArray()` function will always return a non-associative array.