### PR TITLE
Add tabindex so blocks can be tabbed into

### DIFF
--- a/src/assetbundles/matrixmate/dist/js/MatrixMate.js
+++ b/src/assetbundles/matrixmate/dist/js/MatrixMate.js
@@ -115,7 +115,7 @@
                     continue;
                 }
 
-                const $mainMenuBtn = $('<div class="btn menubtn">' + label + '</div>').appendTo($matrixmateButtons);
+                const $mainMenuBtn = $('<div class="btn menubtn" tabindex="0">' + label + '</div>').appendTo($matrixmateButtons);
                 $mainMenuBtn.addClass('dashed');
 
                 const $mainMenu = $('<div class="menu matrixmate-menu" data-matrixmate-group="' + label + '" />').appendTo($matrixmateButtons);


### PR DESCRIPTION
I'm currently on a project switching from Spoon to Matrixmate and I noticed that I couldn't tab into the button to add blocks like I could with Spoon. After looking at what Spoon did it was just adding a tabindex=0 to it. Hopefully this can be added in so that everyone will be able to use keyboard navigation.